### PR TITLE
Feature/kakao naver profile restore

### DIFF
--- a/albaing-api/src/main/java/com/jobjob/albaing/controller/AuthController.java
+++ b/albaing-api/src/main/java/com/jobjob/albaing/controller/AuthController.java
@@ -37,21 +37,24 @@ public class AuthController {
             @RequestPart("user") User user,
             @RequestPart(value = "userProfileImage", required = false) MultipartFile userProfileImage) {
 
+        // Check if we received a file upload
         if (userProfileImage != null && !userProfileImage.isEmpty()) {
             System.out.println("DEBUG: 파일 업로드 시작 - " + userProfileImage.getOriginalFilename());
 
-            // 파일 업로드 실행
+            // Process file upload
             String imageUrl = fileService.uploadFile(userProfileImage);
             System.out.println("DEBUG: 업로드된 이미지 URL = " + imageUrl);
 
             user.setUserProfileImage(imageUrl);
         } else {
-            System.out.println("DEBUG: userProfileImage가 null 또는 비어 있음");
+            System.out.println("DEBUG: userProfileImage 파일이 제공되지 않음, 이미 설정된 URL을 유지: " + user.getUserProfileImage());
+            // Don't overwrite existing URL in user object if no file is provided
         }
 
-        // 회원가입 로직 실행
+        // Continue with user registration
         Map<String, Object> response = authService.registerUser(user);
 
+        // Rest of your code remains the same
         if ("success".equals(response.get("status"))) {
             resumeService.createResumeForUser(user);
             return ResponseEntity.ok(response);

--- a/albaing-api/src/main/java/com/jobjob/albaing/controller/KakaoAPIController.java
+++ b/albaing-api/src/main/java/com/jobjob/albaing/controller/KakaoAPIController.java
@@ -45,7 +45,7 @@ public class KakaoAPIController {
         String kakaoAuthUrl = "https://kauth.kakao.com/oauth/authorize?response_type=code" +
                 "&client_id=" + kakaoClientId +
                 "&redirect_uri=" + redirectUri +
-                "&scope=profile_nickname,account_email,name,gender,birthday,birthyear";
+                "&scope=profile_nickname,profile_image,account_email,name,gender,birthday,birthyear";
 
         return new RedirectView(kakaoAuthUrl);
     }
@@ -97,6 +97,7 @@ public class KakaoAPIController {
                 : new HashMap<>();
 
         String nickname = (String) properties.get("nickname");
+        String profileImg = (String) properties.get("profile_image");
         String email = kakaoAccount.getOrDefault("email", "").toString();
         String gender = kakaoAccount.getOrDefault("gender", "").toString();
         String birthday = kakaoAccount.getOrDefault("birthday", "").toString();
@@ -133,6 +134,9 @@ public class KakaoAPIController {
         }
         if (!birthyear.isEmpty()) {
             frontendRedirectUri += "&birthyear=" + birthyear;
+        }
+        if (!profileImg.isEmpty()) {
+            frontendRedirectUri += "&profileImage=" + URLEncoder.encode(profileImg, StandardCharsets.UTF_8);
         }
 
 

--- a/albaing-api/src/main/java/com/jobjob/albaing/service/AuthService.java
+++ b/albaing-api/src/main/java/com/jobjob/albaing/service/AuthService.java
@@ -20,7 +20,7 @@ public interface AuthService {
      */
     Map<String, Object> registerUser(User user);
 
-    void registerCompany(Company company);
+    Map<String, Object> registerCompany(Company company);
 
     boolean isUserExist(String email);
 

--- a/albaing-api/src/main/java/com/jobjob/albaing/service/AuthServiceImpl.java
+++ b/albaing-api/src/main/java/com/jobjob/albaing/service/AuthServiceImpl.java
@@ -163,37 +163,80 @@ public class AuthServiceImpl implements AuthService {
     }
 
     @Override
-    public void registerCompany(Company company) {
+    public Map<String, Object> registerCompany(Company company) {
+        Map<String, Object> response = new HashMap<>();
 
         // ✅ 이메일 중복 체크
         if (companyMapper.isCompanyExist(company.getCompanyEmail())) {
-            throw new IllegalArgumentException("이미 가입한 이메일입니다.");
+            response.put("status", "fail");
+            response.put("message", "이미 가입한 이메일입니다.");
+            return response;
         }
 
         // ✅ 전화번호 중복 체크
         if (companyMapper.isCompanyPhoneExist(company.getCompanyPhone())) {
-            throw new IllegalArgumentException("이미 가입한 전화번호입니다.");
+            response.put("status", "fail");
+            response.put("message", "이미 가입한 전화번호입니다.");
+            return response;
         }
 
+        if (company.getCompanyEmail() == null || company.getCompanyEmail().trim().isEmpty()) {
+            response.put("status", "fail");
+            response.put("message", "이메일은 필수 입력값입니다.");
+            return response;
+        }
+        if (company.getCompanyPassword() == null || company.getCompanyPassword().trim().isEmpty()) {
+            response.put("status", "fail");
+            response.put("message", "비밀번호는 필수 입력값입니다.");
+            return response;
+        }
+        if (company.getCompanyName() == null || company.getCompanyName().trim().isEmpty()) {
+            response.put("status", "fail");
+            response.put("message", "회사명은 필수 입력값입니다.");
+            return response;
+        }
+
+        // ✅ 이메일 인증 여부 확인
         if (!verificationService.isEmailVerified(company.getCompanyEmail())) {
-            throw new IllegalArgumentException("이메일 인증이 완료되지 않았습니다.");
+            response.put("status", "fail");
+            response.put("message", "이메일 인증이 완료되지 않았습니다.");
+            return response;
         }
 
-        validateCompanyInput(company);
+        try {
+            // ✅ 기본값 설정
+            LocalDateTime now = LocalDateTime.now();
+            company.setCompanyCreatedAt(now);
+            company.setCompanyUpdatedAt(now);
 
-        String encodedPassword = passwordEncoder.encode(company.getCompanyPassword());
-        company.setCompanyPassword(encodedPassword);
+            if (company.getCompanyApprovalStatus() == null) {
+                company.setCompanyApprovalStatus(Company.ApprovalStatus.approving);
+            }
 
-        LocalDateTime now = LocalDateTime.now();
-        company.setCompanyCreatedAt(now);
-        company.setCompanyUpdatedAt(now);
+            // ✅ 비밀번호 암호화 후 저장
+            String encodedPassword = passwordEncoder.encode(company.getCompanyPassword());
+            company.setCompanyPassword(encodedPassword);
 
-        if (company.getCompanyApprovalStatus() == null) {
-            company.setCompanyApprovalStatus(Company.ApprovalStatus.approving);
+            // **DEBUG: 저장될 companyLogo 확인**
+            System.out.println("DEBUG: 저장될 companyLogo = " + company.getCompanyLogo());
+
+            // ✅ 회원가입 실행
+            companyMapper.registerCompany(company);
+
+            // ✅ 이메일 인증 정보 삭제
+            verificationService.removeEmailVerification(company.getCompanyEmail());
+
+            response.put("status", "success");
+            response.put("message", "기업 회원가입이 성공적으로 완료되었습니다.");
+        } catch (Exception e) {
+            response.put("status", "error");
+            response.put("message", "기업 회원가입 중 오류가 발생했습니다: " + e.getMessage());
+            e.printStackTrace();
         }
 
-        companyMapper.registerCompany(company);
+        return response;
     }
+
 
 
     @Override

--- a/albaing-web/src/pages/auth/register/BusinessValidation.jsx
+++ b/albaing-web/src/pages/auth/register/BusinessValidation.jsx
@@ -1,27 +1,25 @@
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import axios from 'axios';
-import alertModal from "../../../components/modals/AlertModal";
 
 const BusinessValidation = () => {
-    const [companyRegistrationNumber, setCompanyRegistrationNumber] = useState('');
-    const [companyOwnerName, setCompanyOwnerName] = useState('');
-    const [companyOpenDate, setCompanyOpenDate] = useState('');
+    const [licenseNumber, setLicenseNumber] = useState('');
+    const [ownerName, setOwnerName] = useState('');
+    const [openDate, setOpenDate] = useState('');
     const [message, setMessage] = useState('');
     const navigate = useNavigate();
 
-    // 사업자 등록번호 인증
+    // 사업자 등록번호 인증하기 (비동기 처리 없이 axios 사용)
     const validateBusinessNumber = (callback) => {
         const data = {
             "businesses": [
                 {
-                    "b_no": companyRegistrationNumber,
-                    "start_dt": companyOpenDate,
-                    "p_nm": companyOwnerName
+                    "b_no": licenseNumber,
+                    "start_dt": openDate,
+                    "p_nm": ownerName
                 }
             ]
         };
-
 
         axios.post(
             "https://api.odcloud.kr/api/nts-businessman/v1/validate?serviceKey=0rsV2ZpVVbhRdzdow1XYlJ90OFql0qQm1sn7RnDySfIL6euWd5uVi7XFviZDtCZGB2iykgpDi%2BtccmdqSNmY8g%3D%3D",
@@ -34,10 +32,10 @@ const BusinessValidation = () => {
 
                 if (valid === '01') {
                     setMessage("사업자 회원가입이 가능합니다.");
-                    callback(true);
+                    callback(true);  // 인증 성공
                 } else {
                     setMessage("사업자 정보가 일치하지 않거나 회원가입이 불가능합니다.");
-                    callback(false);
+                    callback(false); // 인증 실패
                 }
             })
             .catch(error => {
@@ -45,37 +43,16 @@ const BusinessValidation = () => {
                 setMessage("에러가 발생했습니다.");
                 callback(false);
             });
-
-
     };
 
     // 가입하기
     const businessRegistration = () => {
         validateBusinessNumber((isValid) => {
             if (isValid) {
-                alertModal.openModal({
-                    title: '권한 제한',
-                    message: '사업자 인증에 성공했습니다.',
-                    type: 'success',
-                    onClose: () => navigate('/register/company')
-                });
-
-                // 로컬 스토리지에 저장 (값이 올바르게 저장되는지 콘솔로 확인)
-                console.log("저장되는 값:", { companyRegistrationNumber, companyOwnerName, companyOpenDate });
-
-                // 로컬 스토리지에 저장
-                localStorage.setItem("companyRegistrationNumber", companyRegistrationNumber);
-                localStorage.setItem("companyOwnerName", companyOwnerName);
-                localStorage.setItem("companyOpenDate", companyOpenDate);
-
-                navigate('/register/company'); // RegisterCompany로 이동
-              
+                alert("사업자 인증에 성공했습니다.");
+                navigate('/register/company');
             } else {
-                alertModal.openModal({
-                    title: '정보 불일치',
-                    message: '사업자 정보가 일치하지 않습니다. 다시 확인해주세요.',
-                    type: 'warning',
-                });
+                alert("사업자 정보가 일치하지 않습니다. 다시 확인해주세요.");
             }
         });
     };
@@ -86,20 +63,20 @@ const BusinessValidation = () => {
             <div>
                 <input
                     type="text"
-                    value={companyRegistrationNumber}
-                    onChange={(e) => setCompanyRegistrationNumber(e.target.value)}
+                    value={licenseNumber}
+                    onChange={(e) => setLicenseNumber(e.target.value)}
                     placeholder="사업자 번호를 입력하세요 (숫자만 입력)"
                 />
                 <input
                     type="text"
-                    value={companyOpenDate}
-                    onChange={(e) => setCompanyOpenDate(e.target.value)}
+                    value={openDate}
+                    onChange={(e) => setOpenDate(e.target.value)}
                     placeholder="개업일을 입력하세요 (YYYYMMDD)"
                 />
                 <input
                     type="text"
-                    value={companyOwnerName}
-                    onChange={(e) => setCompanyOwnerName(e.target.value)}
+                    value={ownerName}
+                    onChange={(e) => setOwnerName(e.target.value)}
                     placeholder="대표자 이름을 입력하세요"
                 />
                 <button onClick={() => validateBusinessNumber(() => {})}>인증 확인</button>

--- a/albaing-web/src/pages/auth/register/BusinessValidation.jsx
+++ b/albaing-web/src/pages/auth/register/BusinessValidation.jsx
@@ -3,23 +3,24 @@ import { useNavigate } from 'react-router-dom';
 import axios from 'axios';
 
 const BusinessValidation = () => {
-    const [licenseNumber, setLicenseNumber] = useState('');
-    const [ownerName, setOwnerName] = useState('');
-    const [openDate, setOpenDate] = useState('');
+    const [companyRegistrationNumber, setCompanyRegistrationNumber] = useState('');
+    const [companyOwnerName, setCompanyOwnerName] = useState('');
+    const [companyOpenDate, setCompanyOpenDate] = useState('');
     const [message, setMessage] = useState('');
     const navigate = useNavigate();
 
-    // 사업자 등록번호 인증하기 (비동기 처리 없이 axios 사용)
+    // 사업자 등록번호 인증
     const validateBusinessNumber = (callback) => {
         const data = {
             "businesses": [
                 {
-                    "b_no": licenseNumber,
-                    "start_dt": openDate,
-                    "p_nm": ownerName
+                    "b_no": companyRegistrationNumber,
+                    "start_dt": companyOpenDate,
+                    "p_nm": companyOwnerName
                 }
             ]
         };
+
 
         axios.post(
             "https://api.odcloud.kr/api/nts-businessman/v1/validate?serviceKey=0rsV2ZpVVbhRdzdow1XYlJ90OFql0qQm1sn7RnDySfIL6euWd5uVi7XFviZDtCZGB2iykgpDi%2BtccmdqSNmY8g%3D%3D",
@@ -32,10 +33,10 @@ const BusinessValidation = () => {
 
                 if (valid === '01') {
                     setMessage("사업자 회원가입이 가능합니다.");
-                    callback(true);  // 인증 성공
+                    callback(true);
                 } else {
                     setMessage("사업자 정보가 일치하지 않거나 회원가입이 불가능합니다.");
-                    callback(false); // 인증 실패
+                    callback(false);
                 }
             })
             .catch(error => {
@@ -43,6 +44,8 @@ const BusinessValidation = () => {
                 setMessage("에러가 발생했습니다.");
                 callback(false);
             });
+
+
     };
 
     // 가입하기
@@ -50,7 +53,16 @@ const BusinessValidation = () => {
         validateBusinessNumber((isValid) => {
             if (isValid) {
                 alert("사업자 인증에 성공했습니다.");
-                navigate('/register/company');
+
+                // 로컬 스토리지에 저장 (값이 올바르게 저장되는지 콘솔로 확인)
+                console.log("저장되는 값:", { companyRegistrationNumber, companyOwnerName, companyOpenDate });
+
+                // 로컬 스토리지에 저장
+                localStorage.setItem("companyRegistrationNumber", companyRegistrationNumber);
+                localStorage.setItem("companyOwnerName", companyOwnerName);
+                localStorage.setItem("companyOpenDate", companyOpenDate);
+
+                navigate('/register/company'); // RegisterCompany로 이동
             } else {
                 alert("사업자 정보가 일치하지 않습니다. 다시 확인해주세요.");
             }
@@ -63,20 +75,20 @@ const BusinessValidation = () => {
             <div>
                 <input
                     type="text"
-                    value={licenseNumber}
-                    onChange={(e) => setLicenseNumber(e.target.value)}
+                    value={companyRegistrationNumber}
+                    onChange={(e) => setCompanyRegistrationNumber(e.target.value)}
                     placeholder="사업자 번호를 입력하세요 (숫자만 입력)"
                 />
                 <input
                     type="text"
-                    value={openDate}
-                    onChange={(e) => setOpenDate(e.target.value)}
+                    value={companyOpenDate}
+                    onChange={(e) => setCompanyOpenDate(e.target.value)}
                     placeholder="개업일을 입력하세요 (YYYYMMDD)"
                 />
                 <input
                     type="text"
-                    value={ownerName}
-                    onChange={(e) => setOwnerName(e.target.value)}
+                    value={companyOwnerName}
+                    onChange={(e) => setCompanyOwnerName(e.target.value)}
                     placeholder="대표자 이름을 입력하세요"
                 />
                 <button onClick={() => validateBusinessNumber(() => {})}>인증 확인</button>

--- a/albaing-web/src/pages/auth/register/RegisterCompany.jsx
+++ b/albaing-web/src/pages/auth/register/RegisterCompany.jsx
@@ -31,9 +31,16 @@ const RegisterCompany = () => {
         const storedCompanyOwnerName = localStorage.getItem("companyOwnerName") || '';
         const storedCompanyOpenDate = localStorage.getItem("companyOpenDate") || '';
 
-        setCompanyRegistrationNumber(storedCompanyRegistrationNumber);
+        // 사업자등록번호 변환 함수
+        const formatCompanyRegistrationNumber = (number) => {
+            if (!number) return '';
+            return number.replace(/^(\d{3})(\d{2})(\d{5})$/, "$1-$2-$3");
+        };
+
+        setCompanyRegistrationNumber(formatCompanyRegistrationNumber(storedCompanyRegistrationNumber));
         setCompanyOwnerName(storedCompanyOwnerName);
         setCompanyOpenDate(storedCompanyOpenDate);
+
     }, []);
 
     const requestVerificationCode = () => {

--- a/albaing-web/src/pages/auth/register/RegisterPerson.jsx
+++ b/albaing-web/src/pages/auth/register/RegisterPerson.jsx
@@ -190,7 +190,7 @@ const RegisterPerson = () => {
         const kakaoId = params.get("kakaoId");
         const naverId = params.get("naverId");
 
-        // 사용자 정보 객체 생성
+        // Create user object with common properties
         const user = {
             userEmail,
             userPassword,
@@ -205,31 +205,25 @@ const RegisterPerson = () => {
             naverId: naverId || "",
         };
 
+        // Special handling for social login image URLs
+        if (typeof userProfileImage === "string" && userProfileImage.startsWith("http")) {
+            // Add the URL directly to the user object for social login images
+            user.userProfileImage = userProfileImage;
+        }
+
         const formData = new FormData();
         formData.append("user", new Blob([JSON.stringify(user)], { type: "application/json" }));
 
-        // ✅ userProfileImage가 URL이면 Blob으로 변환 후 추가
-        if (typeof userProfileImage === "string" && userProfileImage.startsWith("http")) {
-            fetch(userProfileImage)
-                .then(res => res.blob())
-                .then(blob => {
-                    const file = new File([blob], "profile.jpg", { type: blob.type });
-                    formData.append("userProfileImage", file);
-                    sendRequest(formData);  // ✅ 파일 변환 후 서버 요청
-                })
-                .catch(error => {
-                    console.error("프로필 이미지 변환 실패:", error);
-                    sendRequest(formData); // 이미지 변환 실패 시라도 회원가입 요청은 진행
-                });
-        } else {
-            if (userProfileImage) {
-                formData.append("userProfileImage", userProfileImage);
-            }
-            sendRequest(formData); // ✅ 기존 파일 업로드
+        // Only append actual file uploads to formData
+        if (userProfileImage instanceof File) {
+            formData.append("userProfileImage", userProfileImage);
         }
+
+        // Send the request
+        sendRequest(formData);
     };
 
-// ✅ Axios 요청 함수 분리
+// The sendRequest function remains the same
     const sendRequest = (formData) => {
         axios.post("/api/auth/register/person", formData, {
             headers: { "Content-Type": "multipart/form-data" },


### PR DESCRIPTION
카카오, 네이버로 회원가입시 프로필 이미지 가져오기 복구.
데이터베이스에 저장된 주소 인터넷 창에서 열어 사진 확인 완료.
프로필 이미지를 설정하는 데는 두 가지 방법으로 나눔.
로컬로 업로드된 파일의 경우: MultipartFile 및 fileService를 통해 처리.
소셜 로그인 URL의 경우: 사용자 개체에 있는 URL을 그대로 유지.

이 접근 방식을 사용하면 브라우저에서 외부 이미지를 다운로드하지 않으므로 CORS 문제가 해결되고 기존 백엔드 인프라와 호환됩니다.